### PR TITLE
Add Disk Service Time graph

### DIFF
--- a/node-exporter-server-metrics/node-exporter-server-metrics.json
+++ b/node-exporter-server-metrics/node-exporter-server-metrics.json
@@ -1057,6 +1057,92 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 26,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": 2,
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "node",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "irate(node_disk_io_time_ms{instance=~\"$node\"}[5m])/1000/(irate(node_disk_reads_completed{instance=~\"$node\"}[5m])+irate(node_disk_writes_completed{instance=~\"$node\"}[5m])) or irate(node_disk_io_time_seconds_total{instance=~\"$node\"}[5m])/(irate(node_disk_reads_completed_total{instance=~\"$node\"}[5m])+irate(node_disk_writes_completed_total{instance=~\"$node\"}[5m]))",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{device}}",
+              "metric": "",
+              "refId": "A",
+              "step": 1200,
+              "target": ""
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Service Time",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "Disk Service Time"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 22,
           "legend": {
             "avg": false,


### PR DESCRIPTION
This is the same metric as `svctm' in iostat(1). It is calculated as
time spent doing I/O in the given time interval divided by number of
I/Os completed in that time interval.

Here is Grafana snapshot testing different node_exporter versions with this graph: https://snapshot.raintank.io/dashboard/snapshot/ShKXcbEDUHOqgjsoaoCzl3KNooVrv1LA